### PR TITLE
Patch unit tests by updating `OTIO_PLUGIN_MANIFEST_PATH` env var

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { file="LICENSE" }
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "opentimelineio >= 0.15.0"
+    "opentimelineio >= 0.17.0.dev1"
 ]
 
 classifiers = [

--- a/tests/test_svg_adapter.py
+++ b/tests/test_svg_adapter.py
@@ -10,6 +10,10 @@ import xml.etree.ElementTree as ET
 
 import opentimelineio as otio
 
+os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = os.pathsep.join(
+    ["$OTIO_PLUGIN_MANIFEST_PATH", "../src/otio_svg_adapter/plugin_manifest.json"]
+)
+
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 SIMPLE_CUT_OTIO_PATH = os.path.join(SAMPLE_DATA_DIR, 'simple_cut.otio')
 SIMPLE_CUT_SVG_PATH = os.path.join(SAMPLE_DATA_DIR, 'simple_cut.svg')


### PR DESCRIPTION
The unit tests modules were not functional without registering `otio_svg_adapter/plugin_manifest.json` with the `OTIO_PLUGIN_MANIFEST_PATH` env var.